### PR TITLE
[SPARK-12941][SQL] Spark-SQL JDBC Oracle dialect fails to map string datatypes to Oracle VARCHAR datatype

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -247,7 +247,7 @@ case object OracleDialect extends JdbcDialect {
       None
     }
   }
-  
+
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
     case StringType => Some(JdbcType("VARCHAR2(255)", java.sql.Types.VARCHAR))
     case _ => None

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -247,4 +247,9 @@ case object OracleDialect extends JdbcDialect {
       None
     }
   }
+  
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+    case StringType => Some(JdbcType("VARCHAR2(255)", java.sql.Types.VARCHAR))
+    case _ => None
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -447,7 +447,8 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter {
 
   test("OracleDialect type mapping") {
     val oracleDialect = JdbcDialects.get("jdbc:oracle://127.0.0.1/db")
-    assert(oracleDialect.getJDBCType(StringType).map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
+    assert(oracleDialect.getJDBCType(StringType).
+      map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -450,5 +450,4 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter {
     assert(oracleDialect.getJDBCType(StringType).
       map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -445,4 +445,9 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter {
     assert(agg.getCatalystType(1, "", 1, null) == Some(StringType))
   }
 
+  test("OracleDialect type mapping") {
+    val oracleDialect = JdbcDialects.get("jdbc:oracle://127.0.0.1/db")
+    assert(oracleDialect.getJDBCType(StringType).map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
+  }
+
 }


### PR DESCRIPTION
Adding a getJDBCType() method to the JdbcDialects.scala for OracleDialect,which would create a VARCHAR type for Oracle create table operations.Currently the type TEXT is throwing exceptions which is incompatible to Oracle
