### PR TITLE
[SPARK-12941][Master]Spark-SQL JDBC Oracle dialect fails to map string datatypes to Oracle datatype

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -645,4 +645,10 @@ class JDBCSuite extends SparkFunSuite
       r => assert(!List("testPass", "testUser").exists(r.toString.contains))
     }
   }
+
+  test("SPARK 12941: The data type mapping for StringType to Oracle") {
+    val oracleDialect = JdbcDialects.get("jdbc:oracle://127.0.0.1/db")
+    assert(oracleDialect.getJDBCType(StringType).
+      map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A test suite added for the bug fix -SPARK 12941; for the mapping of the StringType to corresponding in Oracle
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
manual tests done.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Adding a test suite for the SPARK 12941 for the testing of the StringType mapping to Oracle Varchar
